### PR TITLE
tiktoken ^0.4.0 -> >=0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Killian Lucas <killian@drinkwater.ai>"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-tiktoken = "^0.4.0"
+tiktoken = ">=0.4.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
to soleve: 
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
tokentrim 0.1.10 requires tiktoken<0.5.0,>=0.4.0, but you have tiktoken 0.5.1 which is incompatible.